### PR TITLE
Mac address formatting added to standardise output

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,10 @@ function parseRow (row) {
   var macAddress = row.slice(macStart, macEnd)
   // Ignore unresolved hosts.
   if (macAddress === '(incomplete)') return
+  // Format for always 2 digits
+  macAddress = macAddress.replace(/^.:/, '0$&')
+    .replace(/:.(?=:|$)/g, ':0X$&')
+    .replace(/X:/g, '');
 
   return {
     name: name,


### PR DESCRIPTION
Different arp cmd implementations produce differently formatted outputs: some format mac addresses so that its elements always include leading zeros e.g. 00:0f:b1:3c:d0:0f, some others omit those e.g. 0:f:b1:3c:d0:f.

I would rather have standardised output so that e.g. if you want to check for a presence of a certain device in the network you can do simple string matching regardless of arp cmd implementation.   