### PR TITLE
Fixed win32 parser for better windows support

### DIFF
--- a/src/parser/win32.js
+++ b/src/parser/win32.js
@@ -2,7 +2,7 @@
  * Parses each row in the arp table into { name, ip, mac } on win32.
  */
 module.exports = function parseRow (row, servers) {
-  var chunks = row.split('\t')
+  var chunks = row.split(' ').filter(function (el) { return el.length > 1 });
 
   // Parse name.
   var ipAddress = chunks[0]

--- a/src/parser/win32.js
+++ b/src/parser/win32.js
@@ -2,7 +2,7 @@
  * Parses each row in the arp table into { name, ip, mac } on win32.
  */
 module.exports = function parseRow (row, servers) {
-  var chunks = row.split(' ').filter(function (el) { return el.length > 1 });
+  var chunks = row.split(/\s+/g).filter(function (el) { return el.length > 1 })
 
   // Parse name.
   var ipAddress = chunks[0]


### PR DESCRIPTION
Windows 10 return string from child_process that doesn't contain "\t" characters. 
I tested this split function on a Win7/10 and it works like a charm :) 
