### PR TITLE
fix: validate ip address before executing command for 'find'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,10 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
-- increase `maxBuffer` of `cp.exec` to 10MB (1024*1024*10), fixes #10
+- increase `maxBuffer` of `cp.exec` to 10MB (1024*1024*10), fixes [#10](https://github.com/DylanPiercey/local-devices/issues/10)
+- fix: add timeout options when exec arp ([#13](https://github.com/DylanPiercey/local-devices/pull/13))
+- Fixed win32 parser for better windows support ([#9](https://github.com/DylanPiercey/local-devices/pull/9))
+- validate ip address before executing command for 'find' ([#16](https://github.com/DylanPiercey/local-devices/pull/16))
 
 ## [2.0.0] - 2019-02-10
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -63,6 +63,10 @@ describe('local-devices', () => {
         expect(result).toBeUndefined()
       })
 
+      it('rejects when the host is not a valid ip address', async () => {
+        await expect(find('127.0.0.1 | mkdir attacker')).rejects.toThrow('Invalid IP')
+      })
+
       it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find without an ip', async () => {
         await find()
         expect(cp.exec).toHaveBeenCalledWith('arp -a', { 'maxBuffer': TEN_MEGA_BYTE, 'timeout': ONE_MINUTE })

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,10 @@ function parseAll (data) {
  * Reads the arp table for a single address.
  */
 function arpOne (address) {
+  if (!ip.isV4Format(address) && !ip.isV6Format(address)) {
+    return Promise.reject(new Error('Invalid IP address provided.'))
+  }
+
   return cp.exec('arp -n ' + address, options).then(parseOne)
 }
 


### PR DESCRIPTION
Currently it is possible for an attacker to execute an arbitrary command on a host system by using the `find` api since the argument provided is passed directly into a command string.

eg:

```js
var userInput = '127.0.0.1 | mkdir attacker';
find(userInput);
```

This PR fixes this potential security issue by first validating the IP address for the `find` api.

//cc @natterstefan 