### PR TITLE
Added flag to skip name resolution

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -29,6 +29,8 @@ describe('local-devices', () => {
         })
       })
 
+      afterEach(() => cp.exec.mockClear())
+
       it('returns the result of all IPs', async () => {
         const result = await find()
         expect(result).toEqual([
@@ -85,6 +87,11 @@ describe('local-devices', () => {
       it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find without an ip', async () => {
         await find()
         expect(cp.exec).toHaveBeenCalledWith('arp -a', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
+      })
+
+      it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find without an ip and skip name resolution', async () => {
+        await find(null, true)
+        expect(cp.exec).toHaveBeenCalledWith('arp -an', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
       })
 
       it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find with a single ip', async () => {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
       "describe",
       "beforeAll",
       "afterAll",
+      "beforeEach",
+      "afterEach",
       "it",
       "expect"
     ]


### PR DESCRIPTION
It was noticed on my mac and raspberry pi that `arm -a` can take a while whilst it resolves hostnames. A more performant approach is to use `arp -an` which does not resolve host names. With the obvious caveat that host names are not returned.

As a side point neither my mac or raspberry pi return host names.