### PR TITLE
replaced arp with ip on linux (arp is deprecated). 'arp -a' -> 'ip n'…

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -64,7 +64,7 @@ describe('local-devices', () => {
         }
 
         expect(result).toEqual(
-          { name: '?', ip: '192.168.0.222', mac: '00:12:34:56:78:92' }
+          process.platform.includes('linux') ? undefined : { name: '?', ip: '192.168.0.222', mac: '00:12:34:56:78:92' }
         )
       })
 
@@ -84,12 +84,12 @@ describe('local-devices', () => {
 
       it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find without an ip', async () => {
         await find()
-        expect(cp.exec).toHaveBeenCalledWith('arp -a', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
+        expect(cp.exec).toHaveBeenCalledWith(process.platform.includes('linux') ? 'ip n' : 'arp -a', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
       })
 
       it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find with a single ip', async () => {
         await find('192.168.0.242')
-        expect(cp.exec).toHaveBeenCalledWith('arp -n 192.168.0.242', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
+        expect(cp.exec).toHaveBeenCalledWith((process.platform.includes('linux') ? 'ip n s ' : 'arp -n ') + '192.168.0.242', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
       })
     })
   })

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -13,13 +13,13 @@ const mockHosts = [
 ]
 
 const mockLinuxHosts = [
-  '? (192.168.0.202) at 00:12:34:56:78:90 [ether] on eth0',
-  '? (192.168.0.212) at 00:12:34:56:78:91 [ether] on eth0',
-  '? (192.168.0.222) at 00:12:34:56:78:92 [ether] on eth0',
-  '? (192.168.0.232) at 00:12:34:56:78:93 [ether] on eth0',
-  '? (192.168.1.234) at 00:12:34:56:78:94 [ether] on eth0',
+  '192.168.0.202 dev eth0 lladdr 00:12:34:56:78:90 REACHABLE',
+  '192.168.0.212 dev eth0 lladdr 00:12:34:56:78:91 REACHABLE',
+  '192.168.0.222 dev eth0 lladdr 00:12:34:56:78:92 REACHABLE',
+  '192.168.0.232 dev eth0 lladdr 00:12:34:56:78:93 REACHABLE',
+  '192.168.1.234 dev eth0 lladdr 00:12:34:56:78:94 REACHABLE',
   // "special" cases (eg. unresolved hosts)
-  '? (192.168.0.242) at <incomplete> on eth0',
+  '192.168.0.242 dev eth0 INCOMPLETE',
   '192.168.0.243 (192.168.0.243) -- no entry' // host has no entry in the arp table
 ]
 
@@ -53,9 +53,9 @@ function mockPrepareLinuxHosts (command) {
   let r = workingHosts.join('\n')
 
   // then define the current use-case (arp all or arp one)
-  if (command.includes('-n')) {
+  if (command.includes('n s')) {
     // receive the ip address of the request and the mac address from the mocked hosts
-    const ip = command.match(/arp -(.*){1} (.*)/)[2]
+    const ip = command.match(/ip (.*){1} (.*)/)[2]
     const host = mockLinuxHosts.find(i => i.indexOf(ip) >= 0)
 
     // and finally prepare the arp output for the tests

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,8 @@ function pingServer (address) {
  * Reads the arp table.
  */
 function arpAll () {
-  return cp.exec('arp -a', options).then(parseAll)
+  const script = process.platform.includes('linux') ? 'ip n' : 'arp -a';
+  return cp.exec(script, options).then(parseAll)
 }
 
 /**
@@ -142,7 +143,8 @@ function arpOne (address) {
     return Promise.reject(new Error('Invalid IP address provided.'))
   }
 
-  return cp.exec('arp -n ' + address, options).then(parseOne)
+  const script =  process.platform.includes('linux') ? 'ip n s ' + address : 'arp -n ' + address;
+  return cp.exec(script, options).then(parseOne)
 }
 
 /**
@@ -159,8 +161,8 @@ function parseOne (data) {
       return
     }
 
-    // remove first row (containing "headlines")
-    var rows = data[0].split('\n').slice(1)[0]
+    // remove first row (containing "headlines", not in linux)
+    var rows = process.platform.includes('linux') ? data[0] : data[0].split('\n').slice(1)[0]
     return parseLinux(rows, servers, true)
   } else if (process.platform.includes('win32')) {
     return // currently not supported

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ function pingServer (address) {
  * Reads the arp table.
  */
 function arpAll () {
-  const script = process.platform.includes('linux') ? 'ip n' : 'arp -a';
+  const script = process.platform.includes('linux') ? 'ip n' : 'arp -a'
   return cp.exec(script, options).then(parseAll)
 }
 
@@ -143,7 +143,7 @@ function arpOne (address) {
     return Promise.reject(new Error('Invalid IP address provided.'))
   }
 
-  const script =  process.platform.includes('linux') ? 'ip n s ' + address : 'arp -n ' + address;
+  const script = process.platform.includes('linux') ? 'ip n s ' + address : 'arp -n ' + address
   return cp.exec(script, options).then(parseOne)
 }
 

--- a/src/parser/linux.js
+++ b/src/parser/linux.js
@@ -7,7 +7,7 @@ module.exports = function parseLinux (row, servers, parseOne) {
   var result = {}
 
   // Ignore unresolved hosts.
-  if (row === '' || row.indexOf('incomplete') >= 0) {
+  if (row === '' || row.indexOf('INCOMPLETE') >= 0 || row.indexOf('FAILED') >= 0 || row.indexOf('STALE') >= 0) {
     return
   }
 
@@ -30,14 +30,14 @@ function prepareOne (chunks) {
   return {
     name: '?', // a hostname is not provided on the raspberry pi (linux)
     ip: chunks[0],
-    mac: chunks[2]
+    mac: chunks[4]
   }
 }
 
 function prepareAll (chunks) {
   return {
-    name: chunks[0],
-    ip: chunks[1].match(/\((.*)\)/)[1],
-    mac: chunks[3]
+    name: '?', // ip n not show name
+    ip: chunks[0],
+    mac: chunks[4]
   }
 }


### PR DESCRIPTION
 replaced arp with ip on linux (arp is deprecated). searching for devices on linux is now faster.