### PR TITLE
Switch to using an object for the arguments and accept a new `arpPath` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ find({ skipNameResolution: true }).then(devices => {
     ]
     */
 })
+
+// Find all devices, specifying your own path for the `arp` binary 
+find({ arpPath: '/usr/sbin/arp' }).then(devices => {
+    devices /*
+    [
+      { name: '?', ip: '192.168.0.10', mac: '...' },
+      { name: '?', ip: '192.168.0.50', mac: '...' },
+      { name: '?', ip: '192.168.0.155', mac: '...' },
+      { name: '?', ip: '192.168.0.211', mac: '...' }
+    ]
+    */
+})
+```
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ find().then(devices => {
 })
 
 // Find a single device by ip address.
-find('192.168.0.10').then(device => {
+find({ address: '192.168.0.10' }).then(device => {
   device /*
   {
     name: '?',
@@ -54,7 +54,7 @@ find('192.168.0.10').then(device => {
 })
 
 // Find all devices within 192.168.0.1 to 192.168.0.25 range
-find('192.168.0.1-192.168.0.25').then(devices => {
+find({ address: '192.168.0.1-192.168.0.25' }).then(devices => {
     devices /*
     [
       { name: '?', ip: '192.168.0.10', mac: '...' },
@@ -66,7 +66,7 @@ find('192.168.0.1-192.168.0.25').then(devices => {
 })
 
 // Find all devices within /24 subnet range of 192.168.0.x
-find('192.168.0.0/24').then(devices => {
+find({ address: '192.168.0.0/24' }).then(devices => {
     devices /*
     [
       { name: '?', ip: '192.168.0.10', mac: '...' },
@@ -79,7 +79,7 @@ find('192.168.0.0/24').then(devices => {
 
 // Find all devices without resolving host names (Uses 'arp -an') - this is more performant if hostnames are not needed 
 // (This flag is ignored on Windows machines as 'arp -an' is not supported)
-find(null, true).then(devices => {
+find({ skipNameResolution: true }).then(devices => {
     devices /*
     [
       { name: '?', ip: '192.168.0.10', mac: '...' },

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -108,6 +108,11 @@ describe('local-devices', () => {
         await find({ address: '192.168.0.242' })
         expect(cp.exec).toHaveBeenCalledWith('arp -n 192.168.0.242', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
       })
+
+      it('invokes cp.exec with maxBuffer of 10 MB, a timeout of 1 minute and a custom arp binary, when invoking find with an arpPath', async () => {
+        await (find({ arpPath: '/usr/sbin/arp' }))
+        expect(cp.exec).toHaveBeenCalledWith('/usr/sbin/arp -a', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
+      })
     })
   })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -49,21 +49,21 @@ describe('local-devices', () => {
       })
 
       it('returns all IPs within /24 range', async () => {
-        const result = await find('192.168.1.0/24')
+        const result = await find({ address: '192.168.1.0/24' })
         expect(result).toEqual([
           { name: '?', ip: '192.168.1.234', mac: '00:12:34:56:78:94' }
         ])
       })
 
       it('returns all IPs within 1-254 range', async () => {
-        const result = await find('192.168.1.1-192.168.1.254')
+        const result = await find({ address: '192.168.1.1-192.168.1.254' })
         expect(result).toEqual([
           { name: '?', ip: '192.168.1.234', mac: '00:12:34:56:78:94' }
         ])
       })
 
       it('returns the result of a single IP (Note: undefined on win32)', async () => {
-        const result = await find('192.168.0.222')
+        const result = await find({ address: '192.168.0.222' })
 
         if (process.platform.includes('win32')) {
           // not supported yet
@@ -77,17 +77,17 @@ describe('local-devices', () => {
       })
 
       it('returns undefined, when the host is not resolved', async () => {
-        const result = await find('192.168.0.242')
+        const result = await find({ address: '192.168.0.242' })
         expect(result).toBeUndefined()
       })
 
       it('returns undefined, when the host does not exist in arp table', async () => {
-        const result = await find('192.168.0.243')
+        const result = await find({ address: '192.168.0.243' })
         expect(result).toBeUndefined()
       })
 
       it('rejects when the host is not a valid ip address', async () => {
-        await expect(find('127.0.0.1 | mkdir attacker')).rejects.toThrow('Invalid IP')
+        await expect(find({ address: '127.0.0.1 | mkdir attacker' })).rejects.toThrow('Invalid IP')
       })
 
       it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find without an ip', async () => {
@@ -96,7 +96,7 @@ describe('local-devices', () => {
       })
 
       it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find without an ip and skip name resolution', async () => {
-        await find(null, true)
+        await find({ address: null, skipNameResolution: true })
         if (process.platform.includes('win32')) {
           expect(cp.exec).toHaveBeenCalledWith('arp -a', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
         } else {
@@ -105,7 +105,7 @@ describe('local-devices', () => {
       })
 
       it('invokes cp.exec with maxBuffer of 10 MB and a timeout of 1 minute, when invoking find with a single ip', async () => {
-        await find('192.168.0.242')
+        await find({ address: '192.168.0.242' })
         expect(cp.exec).toHaveBeenCalledWith('arp -n 192.168.0.242', { maxBuffer: TEN_MEGA_BYTE, timeout: ONE_MINUTE })
       })
     })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 declare module "local-devices" {
 
-    function findLocalDevices(address?: any): Promise<findLocalDevices.IDevice[]>;
+    function findLocalDevices(address?: any, skipNameResolution?: boolean, arpPath?: string): Promise<findLocalDevices.IDevice[]>;
 
     namespace findLocalDevices
     {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 declare module "local-devices" {
 
-    function findLocalDevices(opts: { address?: any, skipNameResolution?: boolean, arpPath?: string }): Promise<findLocalDevices.IDevice[]>;
+    function findLocalDevices(opts?: { address?: any, skipNameResolution?: boolean, arpPath?: string }): Promise<findLocalDevices.IDevice[]>;
 
     namespace findLocalDevices
     {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 declare module "local-devices" {
 
-    function findLocalDevices(address?: any, skipNameResolution?: boolean, arpPath?: string): Promise<findLocalDevices.IDevice[]>;
+    function findLocalDevices(opts: { address?: any, skipNameResolution?: boolean, arpPath?: string }): Promise<findLocalDevices.IDevice[]>;
 
     namespace findLocalDevices
     {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const options = {
 /**
  * Finds all local devices (ip and mac address) connected to the current network.
  */
-module.exports = function findLocalDevices (address, skipNameResolution = false) {
+module.exports = function findLocalDevices (address = '', skipNameResolution = false, arpPath = 'arp') {
   var key = String(address)
 
   if (isRange(address)) {
@@ -38,9 +38,9 @@ module.exports = function findLocalDevices (address, skipNameResolution = false)
 
   if (!lock[key]) {
     if (!address || isRange(key)) {
-      lock[key] = pingServers().then(() => arpAll(skipNameResolution)).then(unlock(key))
+      lock[key] = pingServers().then(() => arpAll(skipNameResolution, arpPath)).then(unlock(key))
     } else {
-      lock[key] = pingServer(address).then(arpOne).then(unlock(key))
+      lock[key] = pingServer(address).then(address => arpOne(address, arpPath)).then(unlock(key))
     }
   }
 
@@ -101,9 +101,9 @@ function pingServer (address) {
 /**
  * Reads the arp table.
  */
-function arpAll (skipNameResolution = false) {
+function arpAll (skipNameResolution = false, arpPath) {
   const isWindows = process.platform.includes('win32')
-  const cmd = (skipNameResolution && !isWindows) ? 'arp -an' : 'arp -a'
+  const cmd = (skipNameResolution && !isWindows) ? `${arpPath} -an` : `${arpPath} -a`
   return cp.exec(cmd, options).then(parseAll)
 }
 
@@ -139,12 +139,12 @@ function parseAll (data) {
 /**
  * Reads the arp table for a single address.
  */
-function arpOne (address) {
+function arpOne (address, arpPath) {
   if (!ip.isV4Format(address) && !ip.isV6Format(address)) {
     return Promise.reject(new Error('Invalid IP address provided.'))
   }
 
-  return cp.exec('arp -n ' + address, options).then(parseOne)
+  return cp.exec(`${arpPath} -n ${address}`, options).then(parseOne)
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const options = {
 /**
  * Finds all local devices (ip and mac address) connected to the current network.
  */
-module.exports = function findLocalDevices (address = '', skipNameResolution = false, arpPath = 'arp') {
+module.exports = function findLocalDevices ({ address = '', skipNameResolution = false, arpPath = 'arp' } = {}) {
   var key = String(address)
 
   if (isRange(address)) {


### PR DESCRIPTION
This updates the API of the `findLocalDevices` function to allow you to optionally specify the path of the `arp` executable using the `arpPath` option, rather than assuming that it is available in the `PATH`.

As part of this change, I make a **breaking change** to the API of the function, switching from positional arguments to a keyed object. This makes the API more friendly and discoverable as the number of options grows, and means you don't have to use `null`s to say "I don't want to set this option".

It also corrects the `findLocalDevices` function type to reflect the `skipNameResolution` argument which is already accepted.